### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+src
+flow-typed
+yarn.lock
+rollup.dev.js
+rollup.prod.js
+.eslintrc.json
+.flowconfig

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "flow": "flow",
-    "quality": "npm run flow && npm run lint && npm run test"
+    "quality": "npm run flow && npm run lint && npm run test",
+	"prepublish": "npm run quality && npm run build"
   },
   "dependencies": {
     "react": "^15.5.4",


### PR DESCRIPTION
What is inside `.npmignore` will be ignored during publishing.